### PR TITLE
add custom allocators

### DIFF
--- a/bench/bench_net_exc.c
+++ b/bench/bench_net_exc.c
@@ -2,13 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include "sk_solv.h"
-#include "sk_sys.h"
-#include "sk_scheme.h"
-#include "sk_dat.h"
-#include "sk_out.h"
-#include "sk_sparse.h"
-#include "sk_net.h"
+#include "sddekit.h"
 
 typedef struct { sk_out out; void *outd; } bench_out_ignore_c_data;
 
@@ -66,7 +60,7 @@ int main() {
 	sk_net_init1(&netd, n, sk_sys_exc, &excd, 2, 1, nnz, Or, Ic, w, d);
 
 	/* setup scheme & solver */
-	x0 = malloc (sizeof(double)*2*n);
+	x0 = sk_malloc (sizeof(double)*2*n);
 	for (i=0; i<(2*n); i++)
 		x0[i] = 0.0;
 	sk_sch_heun_init(&heund, 2*n);
@@ -78,13 +72,13 @@ int main() {
 	sk_solv_cont(&solv);
 
 	/* clean up */
-	free(w);
-	free(x0);
-	free(d);
-	free(Or);
-	free(Ic);
-	free(sw);
-	free(sd);
+	sk_free(w);
+	sk_free(x0);
+	sk_free(d);
+	sk_free(Or);
+	sk_free(Ic);
+	sk_free(sw);
+	sk_free(sd);
 	sk_out_file_free(&filed);
 	sk_out_tavg_free(&tavgd);
 	sk_out_tee_free(&teed);

--- a/bench/bench_randn_axpy_nnz.c
+++ b/bench/bench_randn_axpy_nnz.c
@@ -5,6 +5,7 @@
 #include <time.h>
 
 #include "randomkit.h"
+#include "sk_malloc.h"
 
 int main()
 {
@@ -18,8 +19,8 @@ int main()
 	m = 10;
 	rk_seed(42, &rng);
 
-	g = malloc (sizeof(double) * n);
-	z = malloc (sizeof(double) * n);
+	g = sk_malloc (sizeof(double) * n);
+	z = sk_malloc (sizeof(double) * n);
 	for (i=1; i<n; i+=100)
 	{
 		for (j=0; j<n; j++) g[i] = 0.0;

--- a/include/sddekit.h
+++ b/include/sddekit.h
@@ -1,0 +1,26 @@
+/* Apache 2.0 INS-AMU 2015 */
+
+#ifndef SDDEKIT_H
+#define SDDEKIT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "sk_dat.h"
+#include "sk_hist.h"
+#include "sk_malloc.h"
+#include "sk_net.h"
+#include "sk_out.h"
+#include "sk_scheme.h"
+#include "sk_solv.h"
+#include "sk_sparse.h"
+#include "sk_sys.h"
+#include "sk_test.h"
+#include "sk_util.h"
+
+#ifdef __cplusplus
+}; /* extern "C" */
+#endif
+
+#endif

--- a/include/sk_malloc.h
+++ b/include/sk_malloc.h
@@ -1,0 +1,36 @@
+/* Apache 2.0 INS-AMU 2015 */
+
+#ifndef SK_MALLOC_H
+#define SK_MALLOC_H
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void*(*sk_malloc_t)(size_t size);
+typedef void*(*sk_realloc_t)(void *ptr, size_t size);
+typedef void(*sk_free_t)(void *ptr);
+
+/**
+ * Set custom allocators to be used whenever sk_ calls require allocating or freeing 
+ * memory.
+ */
+void sk_malloc_set_allocators(sk_malloc_t malloc, sk_realloc_t realloc, sk_free_t free);
+
+/**
+ * Set allocators to stdlib functions (malloc, realloc, free)
+ */
+void sk_malloc_set_stdlib_allocators();
+
+void *sk_malloc(size_t size);
+void *sk_realloc(void *ptr, size_t size);
+void sk_free(void *ptr);
+
+
+#ifdef __cplusplus
+}; /* extern "C" */
+#endif
+
+#endif

--- a/include/sk_util.h
+++ b/include/sk_util.h
@@ -39,14 +39,6 @@ int sk_util_uniqi(const int n,
 
 int sk_util_fill_gauss(rk_state *rng, int nx, double *x);
 
-#ifdef SKDEBUG
-#define SK_MALLOCHECK(ptr) \
-	if ((ptr)==NULL) \
-		fprintf(stderr, "[sk_util] NULL malloc at %s:%d `%s'\n", __FILE__, __LINE__, #ptr);
-#else
-#define SK_MALLOCHECK(ptr)  ptr
-#endif
-
 #ifdef __cplusplus
 }; /* extern "C" */
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_definitions(-DSKDEBUG)
 if(CMAKE_COMPILER_IS_GNUCC)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -fstrict-aliasing -Wstrict-aliasing")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ansi")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -fstrict-aliasing -Wstrict-aliasing -ansi")
 endif()
+
 set(libsk_srcs randomkit.c sk_dat.c sk_hist.c sk_net.c sk_out.c
 	sk_scheme.c sk_solv.c sk_sparse.c sk_sys.c sk_sys_wc.c
-	sk_util.c)
+	sk_util.c sk_malloc.c)
 add_library(sk ${libsk_srcs})
 
 if (UNIX)

--- a/src/sk_dat.c
+++ b/src/sk_dat.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <math.h>
 
-#include "sk_util.h"
+#include "sk_malloc.h"
 
 int sk_dat_read_square_matrix(char *fname, int *n, double **w)
 {
@@ -32,7 +32,7 @@ int sk_dat_read_square_matrix(char *fname, int *n, double **w)
 	rewind(fd);
 	/* setup memory */
 	*n = (int) sqrt(nn);
-	SK_MALLOCHECK(wi = malloc (sizeof(double)*nn));
+	wi = sk_malloc (sizeof(double)*nn);
 	*w = wi;
 	if (wi==NULL) {
 		fclose(fd);

--- a/src/sk_hist.c
+++ b/src/sk_hist.c
@@ -6,17 +6,17 @@
 
 #include "sk_util.h"
 #include "sk_hist.h"
-
+#include "sk_malloc.h"
 
 static void setup_buffer_structure(sk_hist *h)
 {
 	int i, j, ui;
 	double maxd;
 
-	SK_MALLOCHECK(h->maxd = malloc (sizeof(double) * h->nu));
-	SK_MALLOCHECK(h->lim = malloc (sizeof(double) * (h->nu + 1)));
-	SK_MALLOCHECK(h->len = malloc (sizeof(double) * h->nu));
-	SK_MALLOCHECK(h->pos = malloc (sizeof(double) * h->nu));
+	h->maxd = sk_malloc (sizeof(double) * h->nu);
+	h->lim = sk_malloc (sizeof(double) * (h->nu + 1));
+	h->len = sk_malloc (sizeof(double) * h->nu);
+	h->pos = sk_malloc (sizeof(double) * h->nu);
 
 	/* vi2i requires max(uvi) then filling in vi2i[ui]=i */
 	h->maxvi = 0;
@@ -24,7 +24,7 @@ static void setup_buffer_structure(sk_hist *h)
 		if (h->uvi[i] > h->maxvi)
 			h->maxvi = h->uvi[i];
 
-	SK_MALLOCHECK(h->vi2i = malloc (sizeof(int) * (h->maxvi + 1)));
+	h->vi2i = sk_malloc (sizeof(int) * (h->maxvi + 1));
 
 	for (i=0; i<h->nu; i++)
 	{
@@ -57,31 +57,31 @@ void sk_hist_init(sk_hist * restrict h, int nd, int * restrict vi, double * rest
 	sk_util_uniqi(nd, vi, &(h->nu), &(h->uvi));
 
 	/* alloc & copy the delay values */
-	SK_MALLOCHECK(h->del = malloc (sizeof(double) * nd));
+	h->del = sk_malloc (sizeof(double) * nd);
 	memcpy(h->del, vd, nd * sizeof(double));
 
 	/* and indices */
-	SK_MALLOCHECK(h->vi = malloc (sizeof(int) * nd));
+	h->vi = sk_malloc (sizeof(int) * nd);
 	memcpy(h->vi, vi, nd * sizeof(int));
 
 	/* setup maxd, off, len, pos */
 	setup_buffer_structure(h);
 
 	/* alloc buf */
-	SK_MALLOCHECK(h->buf = malloc (sizeof(double) * h->lim[h->nu]));
+	h->buf = sk_malloc (sizeof(double) * h->lim[h->nu]);
 }
 
 void sk_hist_free(sk_hist *h)
 {
-	free(h->uvi);
-	free(h->del);
-	free(h->vi);
-	free(h->maxd);
-	free(h->lim);
-	free(h->len);
-	free(h->pos);
-	free(h->vi2i);
-	free(h->buf);
+	sk_free(h->uvi);
+	sk_free(h->del);
+	sk_free(h->vi);
+	sk_free(h->maxd);
+	sk_free(h->lim);
+	sk_free(h->len);
+	sk_free(h->pos);
+	sk_free(h->vi2i);
+	sk_free(h->buf);
 }
 
 void sk_hist_fill(sk_hist * restrict h, sk_hist_filler filler, void * restrict fill_data)
@@ -90,8 +90,8 @@ void sk_hist_fill(sk_hist * restrict h, sk_hist_filler filler, void * restrict f
 	double *t;
 
 	n = h->lim[h->nu];
-	SK_MALLOCHECK(t = malloc (sizeof(double) * n));
-	SK_MALLOCHECK(vi = malloc (sizeof(int) * n));
+	t = sk_malloc (sizeof(double) * n);
+	vi = sk_malloc (sizeof(int) * n);
 
 	/* expand indices per buffer element */
 	for (i=0; i<h->nu; i++)
@@ -122,8 +122,8 @@ void sk_hist_fill(sk_hist * restrict h, sk_hist_filler filler, void * restrict f
 
 	filler(fill_data, n, t, vi, h->buf);
 
-	free(t);
-	free(vi);
+	sk_free(t);
+	sk_free(vi);
 }
 
 void sk_hist_get(sk_hist * restrict h, double t, double * restrict aff)

--- a/src/sk_malloc.c
+++ b/src/sk_malloc.c
@@ -1,0 +1,57 @@
+/* Apache 2.0 INS-AMU 2015 */
+
+#ifdef SKDEBUG
+#include <stdio.h>
+#endif
+
+#include "sk_malloc.h"
+
+static sk_malloc_t _sk_malloc = malloc;
+static sk_realloc_t _sk_realloc = realloc;
+static sk_free_t _sk_free = free;
+
+void sk_malloc_set_allocators(sk_malloc_t malloc, sk_realloc_t realloc, sk_free_t free) {
+	if (malloc == NULL || realloc == NULL || free == NULL) {
+#ifdef SKDEBUG
+		fprintf(stderr, "[sk_malloc_set_allocators] at least one fn ptr == NULL\n");
+#endif
+		return;
+	}
+	_sk_malloc = malloc;
+	_sk_realloc = realloc;
+	_sk_free = free;
+}
+
+void sk_malloc_set_stdlib_allocators() {
+	sk_malloc_set_allocators(&malloc, &realloc, &free);
+}
+
+void *sk_malloc(size_t size) {
+	void *new_ptr;
+	new_ptr = (*_sk_malloc)(size);
+#ifdef SKDEBUG
+	if (new_ptr==NULL)
+		fprintf(stderr, "[sk_alloc] alloc returned a NULL pointer.\n");
+#endif
+	return new_ptr;
+}
+
+void *sk_realloc(void *ptr, size_t size) {
+	void *new_ptr;
+	new_ptr = (*_sk_realloc)(ptr, size);
+#ifdef SKDEBUG
+	if (new_ptr==NULL)
+		fprintf(stderr, "[sk_realloc] realloc returned a NULL pointer.\n");
+#endif
+	return new_ptr;
+}
+
+void sk_free(void *ptr) {
+#ifdef SKDEBUG
+	if (ptr==NULL) {
+		fprintf(stderr, "[sk_free] cowardly refusing to free a NULL pointer.\n");
+		return;
+	}
+#endif
+	(*_sk_free)(ptr);
+}

--- a/src/sk_net.c
+++ b/src/sk_net.c
@@ -3,8 +3,7 @@
 #include <string.h> /* memcpy */
 
 #include "sk_net.h"
-#include "sk_util.h" /* SK_MALLOCHECK */
-
+#include "sk_malloc.h"
 
 SK_DEFSYS(sk_net_sys)
 {
@@ -81,11 +80,11 @@ int sk_net_init1(sk_net_data *net, int n, sk_sys sys, void *data,
 	int i, *M, *Ms, *Me;
 	sk_sys *models;
 	void **model_data;
-	SK_MALLOCHECK(M = malloc (sizeof(int) * n));
-	SK_MALLOCHECK(Ms = malloc (sizeof(int)));
-	SK_MALLOCHECK(Me = malloc (sizeof(int)));
-	SK_MALLOCHECK(models = malloc (sizeof(sk_sys)));
-	SK_MALLOCHECK(model_data = malloc (sizeof(void*)));
+	M = sk_malloc (sizeof(int) * n);
+	Ms = sk_malloc (sizeof(int));
+	Me = sk_malloc (sizeof(int));
+	models = sk_malloc (sizeof(sk_sys));
+	model_data = sk_malloc (sizeof(void*));
 	Ms[0] = ns;
 	Me[0] = ne;
 	for(i=0; i<n; i++)
@@ -100,12 +99,12 @@ int sk_net_init1(sk_net_data *net, int n, sk_sys sys, void *data,
 void sk_net_free(sk_net_data *net)
 {
 	if (net->_init1) {
-		free(net->M);
-		free(net->Ms);
-		free(net->Me);
-		free(net->models);
-		free((void*) net->models_data);
-		free(net->cn);
+		sk_free(net->M);
+		sk_free(net->Ms);
+		sk_free(net->Me);
+		sk_free(net->models);
+		sk_free((void*) net->models_data);
+		sk_free(net->cn);
 	}
 }
 
@@ -134,7 +133,7 @@ int sk_net_initn(sk_net_data *net, int n, int m,
 		net->ns += net->Ms[net->M[i]];
 		net->ne += net->Me[net->M[i]];
 	}
-	SK_MALLOCHECK(net->cn = malloc (sizeof(double) * net->ne));
+	net->cn = sk_malloc (sizeof(double) * net->ne);
 	net->_init1 = 0;
 	return 0;
 }

--- a/src/sk_out.c
+++ b/src/sk_out.c
@@ -5,6 +5,7 @@
 
 #include "sk_out.h"
 #include "sk_util.h"
+#include "sk_malloc.h"
 
 /* write data to file */
 
@@ -52,8 +53,8 @@ SK_DEFOUT(sk_out_mem) {
 	(void) t;
 	if (d->capacity==0) {
 		/* first alloc */
-		SK_MALLOCHECK(d->xs = malloc (sizeof(double)*nx));
-		SK_MALLOCHECK(d->cs = malloc (sizeof(double)*nc));
+		d->xs = sk_malloc (sizeof(double)*nx);
+		d->cs = sk_malloc (sizeof(double)*nc);
 		d->capacity = 1;
 	}
 	memcpy(d->xs + d->n_sample*nx, x, sizeof(double)*nx);
@@ -62,10 +63,10 @@ SK_DEFOUT(sk_out_mem) {
 	if (d->n_sample==d->capacity) {
 		double *x_, *c_;
 		/* expand buffer */
-		x_ = realloc (d->xs, sizeof(double)*nx*2*d->capacity);
+		x_ = sk_realloc (d->xs, sizeof(double)*nx*2*d->capacity);
 		if (x_==NULL)
 			return 0;
-		c_ = realloc (d->cs, sizeof(double)*nc*2*d->capacity);
+		c_ = sk_realloc (d->cs, sizeof(double)*nc*2*d->capacity);
 		if (c_==NULL)
 			return 0;
 		d->capacity *= 2;
@@ -77,17 +78,17 @@ SK_DEFOUT(sk_out_mem) {
 
 void sk_out_mem_free(sk_out_mem_data *d) {
 	if (d->xs!=NULL)
-		free(d->xs);
+		sk_free(d->xs);
 	if (d->cs!=NULL)
-		free(d->cs);
+		sk_free(d->cs);
 }
 
 /* split n-ways */
 
 int sk_out_tee_init(sk_out_tee_data *d, int nout) {
 	d->nout = nout;
-	SK_MALLOCHECK(d->outs = malloc (sizeof(sk_out) * nout));
-	SK_MALLOCHECK(d->outd = malloc (sizeof(void*) * nout));
+	d->outs = sk_malloc (sizeof(sk_out) * nout);
+	d->outd = sk_malloc (sizeof(void*) * nout);
 	return 0;
 }
 
@@ -110,8 +111,8 @@ SK_DEFOUT(sk_out_tee) {
 }
 
 void sk_out_tee_free(sk_out_tee_data *d) {
-	free(d->outs);
-	free(d->outd);
+	sk_free(d->outs);
+	sk_free(d->outd);
 }
 
 /* temporal average / downsample */
@@ -134,8 +135,8 @@ SK_DEFOUT(sk_out_tavg) {
 	d = data;
 #define ALL(lim) for(i=0;i<(lim);i++)
 	if (d->x==NULL) {
-		SK_MALLOCHECK(d->x = malloc (sizeof(double) * nx));
-		SK_MALLOCHECK(d->c = malloc (sizeof(double) * nc));
+		d->x = sk_malloc (sizeof(double) * nx);
+		d->c = sk_malloc (sizeof(double) * nc);
 		ALL(nx) d->x[i] = 0.0;
 		ALL(nc) d->c[i] = 0.0;
 	}
@@ -159,8 +160,8 @@ SK_DEFOUT(sk_out_tavg) {
 }
 
 void sk_out_tavg_free(sk_out_tavg_data *d) {
-	free(d->x);
-	free(d->c);
+	sk_free(d->x);
+	sk_free(d->c);
 }
 
 /* spatial filter (bank) 
@@ -174,10 +175,10 @@ int sk_out_sfilt_init(sk_out_sfilt_data *d, int nfilt, int filtlen,
 	d->nfilt = nfilt;
 	d->filtlen = filtlen;
 	nb = nfilt * filtlen * sizeof(double);
-	SK_MALLOCHECK(d->xfilts = malloc(nb));
-	SK_MALLOCHECK(d->cfilts = malloc(nb));
-	SK_MALLOCHECK(d->x = malloc (sizeof(double) * nfilt));
-	SK_MALLOCHECK(d->c = malloc (sizeof(double) * nfilt));
+	d->xfilts = sk_malloc(nb);
+	d->cfilts = sk_malloc(nb);
+	d->x = sk_malloc (sizeof(double) * nfilt);
+	d->c = sk_malloc (sizeof(double) * nfilt);
 	memcpy(d->xfilts, xfilts, nb);
 	memcpy(d->cfilts, cfilts, nb);
 	d->out = out;
@@ -200,9 +201,9 @@ SK_DEFOUT(sk_out_sfilt) {
 }
 
 void sk_out_sfilt_free(sk_out_sfilt_data *d) {
-	free(d->xfilts);
-	free(d->cfilts);
-	free(d->x);
-	free(d->c);
+	sk_free(d->xfilts);
+	sk_free(d->cfilts);
+	sk_free(d->x);
+	sk_free(d->c);
 }
 

--- a/src/sk_scheme.c
+++ b/src/sk_scheme.c
@@ -5,21 +5,21 @@
 #include <stdlib.h>
 
 #include "sk_scheme.h"
-#include "sk_util.h"
+#include "sk_malloc.h"
 
 int sk_sch_id_init(sk_sch_id_data *d, int nx)
 {
-	SK_MALLOCHECK(d->f=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->g=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->z=malloc(sizeof(double)*nx));
+	d->f=sk_malloc(sizeof(double)*nx);
+	d->g=sk_malloc(sizeof(double)*nx);
+	d->z=sk_malloc(sizeof(double)*nx);
 	return 0;
 }
 
 void sk_sch_id_free(sk_sch_id_data *d)
 {
-	free(d->f);
-	free(d->g);
-	free(d->z);
+	sk_free(d->f);
+	sk_free(d->g);
+	sk_free(d->z);
 }
 
 SK_DEFSCH(sk_sch_id) {
@@ -38,17 +38,17 @@ SK_DEFSCH(sk_sch_id) {
 
 int sk_sch_em_init(sk_sch_em_data *d, int nx)
 {
-	SK_MALLOCHECK(d->f=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->g=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->z=malloc(sizeof(double)*nx));
+	d->f=sk_malloc(sizeof(double)*nx);
+	d->g=sk_malloc(sizeof(double)*nx);
+	d->z=sk_malloc(sizeof(double)*nx);
 	return 0;
 }
 
 void sk_sch_em_free(sk_sch_em_data *d)
 {
-	free(d->f);
-	free(d->g);
-	free(d->z);
+	sk_free(d->f);
+	sk_free(d->g);
+	sk_free(d->z);
 }
 
 SK_DEFSCH(sk_sch_em)
@@ -68,10 +68,10 @@ SK_DEFSCH(sk_sch_em)
 
 int sk_sch_emcolor_init(sk_sch_emcolor_data *d, int nx, double lam)
 {
-	SK_MALLOCHECK(d->f=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->g=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->z=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->eps=malloc(sizeof(double)*nx));
+	d->f=sk_malloc(sizeof(double)*nx);
+	d->g=sk_malloc(sizeof(double)*nx);
+	d->z=sk_malloc(sizeof(double)*nx);
+	d->eps=sk_malloc(sizeof(double)*nx);
 	d->first_call = 1;
 	d->lam = lam;
 	return 0;
@@ -79,10 +79,10 @@ int sk_sch_emcolor_init(sk_sch_emcolor_data *d, int nx, double lam)
 
 void sk_sch_emcolor_free(sk_sch_emcolor_data *d)
 {
-	free(d->f);
-	free(d->g);
-	free(d->z);
-	free(d->eps);
+	sk_free(d->f);
+	sk_free(d->g);
+	sk_free(d->z);
+	sk_free(d->eps);
 }
 
 SK_DEFSCH(sk_sch_emcolor)
@@ -113,23 +113,23 @@ SK_DEFSCH(sk_sch_emcolor)
 
 int sk_sch_heun_init(sk_sch_heun_data *d, int nx)
 {
-	SK_MALLOCHECK(d->fl=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->fr=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->gl=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->gr=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->z=malloc(sizeof(double)*nx));
-	SK_MALLOCHECK(d->xr=malloc(sizeof(double)*nx));
+	d->fl=sk_malloc(sizeof(double)*nx);
+	d->fr=sk_malloc(sizeof(double)*nx);
+	d->gl=sk_malloc(sizeof(double)*nx);
+	d->gr=sk_malloc(sizeof(double)*nx);
+	d->z=sk_malloc(sizeof(double)*nx);
+	d->xr=sk_malloc(sizeof(double)*nx);
 	return 0;
 }
 
 void sk_sch_heun_free(sk_sch_heun_data *d)
 {
-	free(d->fl);
-	free(d->fr);
-	free(d->gl);
-	free(d->gr);
-	free(d->z);
-	free(d->xr);
+	sk_free(d->fl);
+	sk_free(d->fr);
+	sk_free(d->gl);
+	sk_free(d->gr);
+	sk_free(d->z);
+	sk_free(d->xr);
 }
 
 SK_DEFSCH(sk_sch_heun)

--- a/src/sk_solv.c
+++ b/src/sk_solv.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 
 #include "sk_solv.h"
-#include "sk_util.h"
+#include "sk_malloc.h"
 
 
 int sk_solv_init(
@@ -30,8 +30,8 @@ int sk_solv_init(
 	s->outd = out_data;
 	s->hf = hf;
 	s->hfd = hfill_data;
-	SK_MALLOCHECK(s->x = malloc (sizeof(double) * nx));
-	SK_MALLOCHECK(s->x0 = malloc (sizeof(double) * nx));
+	s->x = sk_malloc (sizeof(double) * nx);
+	s->x0 = sk_malloc (sizeof(double) * nx);
 	if (nc > 0 && vi!=NULL && vd!=NULL) {
 		int cn;
 		/* TODO allow hist dt to vary */
@@ -41,7 +41,7 @@ int sk_solv_init(
 		/* s->c big enough to accomate aff or eff */
 		if (cn < s->nc)
 			cn = s->nc;
-		SK_MALLOCHECK(s->c = malloc(sizeof(double) * cn));
+		s->c = sk_malloc(sizeof(double) * cn);
 	} else {
 		s->nc = 0;
 		s->c = NULL;
@@ -56,10 +56,10 @@ int sk_solv_init(
 
 void sk_solv_free(sk_solv *s)
 {
-	free(s->x);
-	free(s->x0);
+	sk_free(s->x);
+	sk_free(s->x0);
 	if (s->c != NULL) {
-		free(s->c);
+		sk_free(s->c);
 		sk_hist_free(&s->hist);
 	}
 }

--- a/src/sk_sparse.c
+++ b/src/sk_sparse.c
@@ -5,6 +5,7 @@
 
 #include "sk_sparse.h"
 #include "sk_util.h"
+#include "sk_malloc.h"
 
 int sk_sparse_from_dense(int m, int n, double *dA, double *dB, double eps,
 		int *nnz, int **Or, int **Ic, double **sA, double **sB)
@@ -21,11 +22,11 @@ int sk_sparse_from_dense(int m, int n, double *dA, double *dB, double eps,
 	}
 #undef DO_IF
 	/* alloc */
-	SK_MALLOCHECK(*Or = malloc (sizeof(int)*(m + 1)));
-	SK_MALLOCHECK(*Ic = malloc (sizeof(int)**nnz));
-	SK_MALLOCHECK(*sA = malloc (sizeof(double)**nnz));
+	*Or = sk_malloc (sizeof(int)*(m + 1));
+	*Ic = sk_malloc (sizeof(int)**nnz);
+	*sA = sk_malloc (sizeof(double)**nnz);
 	if (dB!=NULL)
-		SK_MALLOCHECK(*sB = malloc (sizeof(double)**nnz));
+		*sB = sk_malloc (sizeof(double)**nnz);
 	/* copy elements */
 #define DO_IF(cond)\
 		ci = 0;\

--- a/src/sk_util.c
+++ b/src/sk_util.c
@@ -6,9 +6,10 @@
 
 #include "sk_config.h"
 #include "sk_util.h"
+#include "sk_malloc.h"
 
 void sk_util_res_name(char *relname, char **absname) {
-	*absname = malloc (1024);
+	*absname = sk_malloc (1024);
 	sprintf(*absname, "%s/%s", sk_res_dir, relname);
 }
 
@@ -41,13 +42,13 @@ int sk_util_uniqi(
 
 	if (n==1) {
 		*nuniq = 1;
-		SK_MALLOCHECK(*uints = malloc (sizeof(int)));
+		*uints = sk_malloc (sizeof(int));
 		(*uints)[0] = ints[0];
 		return 0;
 	}
 
 	/* sort copy of input vector */
-	SK_MALLOCHECK(ints_copy = (int*) malloc(sizeof(int) * n));
+	ints_copy = (int*) sk_malloc(sizeof(int) * n);
 	memcpy(ints_copy, ints, n*sizeof(int));
 
 	qsort(ints_copy, n, sizeof(int), compare_int);
@@ -58,7 +59,7 @@ int sk_util_uniqi(
 		if (ints_copy[i] != ints_copy[i+1])
 			(*nuniq)++;
 
-	SK_MALLOCHECK(*uints = (int*) malloc (sizeof(int) * *nuniq));
+	*uints = (int*) sk_malloc (sizeof(int) * *nuniq);
 
 	/* copy unique into output array */
 	j = 0;
@@ -67,7 +68,7 @@ int sk_util_uniqi(
 		if (ints_copy[i] != ints_copy[i+1])
 			(*uints)[j++] = ints_copy[i+1];
 
-	free(ints_copy);
+	sk_free(ints_copy);
 	
 	return 0;
 }

--- a/test/test_dat.cpp
+++ b/test/test_dat.cpp
@@ -4,8 +4,7 @@
 
 #include "gtest/gtest.h"
 
-#include "sk_util.h"
-#include "sk_dat.h"
+#include "sddekit.h"
 
 static int sk_res_conn76_tl25[25] = { 
 	2, 2, 0, 2, 0, 
@@ -24,6 +23,6 @@ TEST(dat, read_square_matrix) {
 	EXPECT_EQ(76,n);
 	for (i=0; i<25; i++)
 		EXPECT_EQ(sk_res_conn76_tl25[i], w[(i/5)*76 + (i%5)]);
-	free(w);
-	free(fname);
+	sk_free(w);
+	sk_free(fname);
 }

--- a/test/test_exc.cpp
+++ b/test/test_exc.cpp
@@ -4,9 +4,7 @@
 
 #include "gtest/gtest.h"
 
-#include "sk_solv.h"
-#include "sk_sys.h"
-#include "sk_scheme.h"
+#include "sddekit.h"
 
 typedef struct {
 	int crossed;

--- a/test/test_hist.cpp
+++ b/test/test_hist.cpp
@@ -5,13 +5,7 @@
 
 #include "gtest/gtest.h"
 
-#include "sk_hist.h"
-#include "sk_sys.h"
-#include "sk_net.h"
-#include "sk_sparse.h"
-#include "sk_solv.h"
-#include "sk_scheme.h"
-#include "sk_out.h"
+#include "sddekit.h"
 
 static void hist_t_fill(void *data, int n, double *t, int *indices, double *buf) {
 	/* suppress unused arguments */
@@ -35,7 +29,7 @@ TEST(hist, basic) {
 	vd[0] = 5.5 * dt;
 	vd[1] = 4.5 * dt;
 	vd[2] = 33.3 * dt;
-	h = (sk_hist*) malloc (sizeof(sk_hist));
+	h = (sk_hist*) sk_malloc (sizeof(sk_hist));
 
 	sk_hist_init(h, ND, vi, vd, 0.0, dt);
 	EXPECT_EQ(ND,h->nd);
@@ -84,7 +78,7 @@ TEST(hist, basic) {
 	ASSERT_NEAR(h->buf[36 + 7], 2.0, 1e-15);
 
 	sk_hist_free(h);
-	free(h);
+	sk_free(h);
 }
 
 /* port of TVB's history test */
@@ -214,8 +208,8 @@ TEST(hist, exact) {
 	sk_solv_free(&sol);
 	sk_sch_id_free(&schd);
 	sk_net_free(&net);
-	free(Or);
-	free(Ic);
-	free(nzw);
-	free(nzd);
+	sk_free(Or);
+	sk_free(Ic);
+	sk_free(nzw);
+	sk_free(nzd);
 }

--- a/test/test_net.cpp
+++ b/test/test_net.cpp
@@ -4,9 +4,7 @@
 
 #include "gtest/gtest.h"
 
-#include "sk_net.h"
-#include "sk_sys.h"
-#include "sk_hist.h"
+#include "sddekit.h"
 
 TEST(net, simple) {
 
@@ -20,10 +18,10 @@ TEST(net, simple) {
 	ns = 2;
 	ne = 1;
 	nnz = 2;
-	Or = malloc (sizeof(int)*(n+1));
-	Ic = malloc (sizeof(int)*nnz);
-	w = malloc (sizeof(double)*nnz);
-	d = malloc (sizeof(double)*nnz);
+	Or = sk_malloc (sizeof(int)*(n+1));
+	Ic = sk_malloc (sizeof(int)*nnz);
+	w = sk_malloc (sizeof(double)*nnz);
+	d = sk_malloc (sizeof(double)*nnz);
 	Or[0] = 0;
 	Or[1] = 1;
 	Or[2] = 2;
@@ -37,7 +35,7 @@ TEST(net, simple) {
 	sysd.a = 1.0;
 	sysd.k = 0.5;
 	sysd.tau = 3.0;
-	hist.vi2i = malloc (sizeof(int)*n);
+	hist.vi2i = sk_malloc (sizeof(int)*n);
 	hist.vi2i[0] = 0;
 	hist.vi2i[1] = 1;
 	hist.vi2i[2] = 2;
@@ -67,10 +65,10 @@ TEST(net, simple) {
 	EXPECT_EQ(1,net._init1);
 
 	/* evaluate */
-	x = malloc (sizeof(double) * n*ns);
-	f = malloc (sizeof(double) * n*ns);
-	g = malloc (sizeof(double) * n*ns);
-	c = malloc (sizeof(double) * n*ne);
+	x = sk_malloc (sizeof(double) * n*ns);
+	f = sk_malloc (sizeof(double) * n*ns);
+	g = sk_malloc (sizeof(double) * n*ns);
+	c = sk_malloc (sizeof(double) * n*ne);
 	c[0] = x[0] = 1.0;
 	c[1] = x[2] = 2.0;
 	c[2] = x[4] = 3.0;
@@ -81,13 +79,13 @@ TEST(net, simple) {
 
 	/* clean up */
 	sk_net_free(&net);
-	free(hist.vi2i);
-	free(Or);
-	free(Ic);
-	free(w);
-	free(d);
-	free(x);
-	free(f);
-	free(g);
-	free(c);
+	sk_free(hist.vi2i);
+	sk_free(Or);
+	sk_free(Ic);
+	sk_free(w);
+	sk_free(d);
+	sk_free(x);
+	sk_free(f);
+	sk_free(g);
+	sk_free(c);
 }

--- a/test/test_out.cpp
+++ b/test/test_out.cpp
@@ -4,7 +4,7 @@
 
 #include "gtest/gtest.h"
 
-#include "sk_out.h"
+#include "sddekit.h"
 
 TEST(out, file) {
 	double t, x[2], c[1];

--- a/test/test_solv.cpp
+++ b/test/test_solv.cpp
@@ -2,8 +2,7 @@
 
 #include "gtest/gtest.h"
 
-#include "sk_solv.h"
-#include "randomkit.h"
+#include "sddekit.h"
 
 typedef struct {
 	int n_calls, nx, nc;

--- a/test/test_sparse.cpp
+++ b/test/test_sparse.cpp
@@ -4,9 +4,7 @@
 
 #include "gtest/gtest.h"
 
-extern "C" {
-#include "sk_sparse.h"
-}
+#include "sddekit.h"
 
 TEST(test_sparse, test_sparse_from_dense) {
 	int n, nnz, *Or, *Ic;
@@ -36,9 +34,9 @@ TEST(test_sparse, test_sparse_from_dense) {
 	EXPECT_EQ(A[1],sA[1]);
 	EXPECT_EQ(A[3],sA[2]);
 
-	free(Or);
-	free(Ic);
-	free(sA);
+	sk_free(Or);
+	sk_free(Ic);
+	sk_free(sA);
 
 	/* with auxiliary matrix */
 	sk_sparse_from_dense(n, n, A, B, 0.0, &nnz, &Or, &Ic, &sA, &sB);
@@ -48,10 +46,10 @@ TEST(test_sparse, test_sparse_from_dense) {
 	EXPECT_EQ(B[1],sB[1]);
 	EXPECT_EQ(B[3],sB[2]);
 
-	free(Or);
-	free(Ic);
-	free(sA);
-	free(sB);
+	sk_free(Or);
+	sk_free(Ic);
+	sk_free(sA);
+	sk_free(sB);
 
 	/* apply cutoff */
 	sk_sparse_from_dense(n, n, A, NULL, 1e-5, &nnz, &Or, &Ic, &sA, NULL);
@@ -65,9 +63,9 @@ TEST(test_sparse, test_sparse_from_dense) {
 	EXPECT_EQ(A[0],sA[0]);
 	EXPECT_EQ(A[3],sA[1]);
 
-	free(Or);
-	free(Ic);
-	free(sA);
+	sk_free(Or);
+	sk_free(Ic);
+	sk_free(sA);
 
 	/* with auxiliary matrix */
 	sk_sparse_from_dense(n, n, A, B, 1e-5, &nnz, &Or, &Ic, &sA, &sB);
@@ -76,10 +74,10 @@ TEST(test_sparse, test_sparse_from_dense) {
 	EXPECT_EQ(B[0],sB[0]);
 	EXPECT_EQ(B[3],sB[1]);
 
-	free(Or);
-	free(Ic);
-	free(sA);
-	free(sB);
+	sk_free(Or);
+	sk_free(Ic);
+	sk_free(sA);
+	sk_free(sB);
 }
 
 /*

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -4,7 +4,7 @@
 
 #include "gtest/gtest.h"
 
-#include "sk_util.h"
+#include "sddekit.h"
 
 #define N 10
 
@@ -12,7 +12,7 @@ TEST(util, uniqi) {
 	{
 		int i, *ints, *uints, nuniq;
 
-		ints = (int*) malloc (sizeof(int) * N);
+		ints = (int*) sk_malloc (sizeof(int) * N);
 
 		for (i=0; i<N; i++)
 			ints[i] = (i - 2) % 3;
@@ -26,8 +26,8 @@ TEST(util, uniqi) {
 		EXPECT_EQ( 1,uints[3] );
 		EXPECT_EQ( 2,uints[4] );
 
-		free(uints);
-		free(ints);
+		sk_free(uints);
+		sk_free(ints);
 	}
 
 	{
@@ -36,7 +36,7 @@ TEST(util, uniqi) {
 		sk_util_uniqi(1, &i, &nuniq, &uints);
 		EXPECT_EQ(1,nuniq);
 		EXPECT_EQ(3,uints[0]);
-		free(uints);
+		sk_free(uints);
 	}
 
 	{
@@ -47,6 +47,6 @@ TEST(util, uniqi) {
 		EXPECT_EQ(2,nuniq);
 		EXPECT_EQ(0,uints[0]);
 		EXPECT_EQ(1,uints[1]);
-		free(uints);
+		sk_free(uints);
 	}
 }


### PR DESCRIPTION
This is relevant for #4 because MEX api semantics require copying when calling MATLAB function callbacks, but MATLAB's memory manager (mxMalloc et al) may be faster or avoid copying if used.